### PR TITLE
Sentry/11092 shared mconfig mme

### DIFF
--- a/lte/gateway/c/core/oai/oai_mme/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/oai_mme/CMakeLists.txt
@@ -31,9 +31,24 @@ endif ()
 
 add_executable(mme ${PROJECT_SOURCE_DIR}/oai_mme/oai_mme.c)
 
+# compile the needed macros
+
+create_proto_dir("orc8r" ORC8R_CPP_OUT_DIR)
+
+list(APPEND PROTO_SRCS "")
+list(APPEND PROTO_HDRS "")
+
+set(SMGR_ORC8R_CPP_PROTOS mconfig/mconfigs)
+generate_cpp_protos("${SMGR_ORC8R_CPP_PROTOS}" "${PROTO_SRCS}"
+  "${PROTO_HDRS}" ${ORC8R_PROTO_DIR} ${ORC8R_CPP_OUT_DIR})
+
+find_package(MAGMA_LOGGING REQUIRED)
+find_package(MAGMA_SENTRY REQUIRED)
+
 target_link_libraries(mme
     -Wl,--start-group
     COMMON
+    MAGMA_LOGGING MAGMA_SENTRY
     LIB_3GPP LIB_S1AP LIB_NGAP LIB_SECU LIB_DIRECTORYD LIB_SGS_CLIENT LIB_BSTR
     LIB_HASHTABLE LIB_S6A_PROXY
     TASK_S1AP TASK_NGAP TASK_SCTP_SERVER TASK_SGS TASK_SMS_ORC8R

--- a/lte/gateway/c/core/oai/oai_mme/oai_mme.c
+++ b/lte/gateway/c/core/oai/oai_mme/oai_mme.c
@@ -111,7 +111,9 @@ int main(int argc, char* argv[]) {
   // Initialize Sentry error collection
   // We have to initialize here for now since itti_init asserts on there being
   // only 1 thread
-  initialize_sentry(SENTRY_TAG_MME, &mme_config.sentry_config);
+  sentry_config_t sentry_config;
+  get_sentry_configuration(&sentry_config);
+  initialize_sentry(SENTRY_TAG_MME, &sentry_config);
 
   // Could not be launched before ITTI initialization
   shared_log_itti_connect();

--- a/orc8r/gateway/c/common/sentry/BUILD.bazel
+++ b/orc8r/gateway/c/common/sentry/BUILD.bazel
@@ -40,5 +40,8 @@ cc_library(
     deps = select({
         ":disable_sentry_native": sentry_deps,
         "//conditions:default": sentry_deps + ["@sentry_native//:sentry"],
-    }),
+    }) + [
+        "//orc8r/gateway/c/common/config:mconfig_loader",
+        "//orc8r/protos:mconfigs_cpp_proto",
+    ],
 )

--- a/orc8r/gateway/c/common/sentry/includes/SentryWrapper.h
+++ b/orc8r/gateway/c/common/sentry/includes/SentryWrapper.h
@@ -37,6 +37,11 @@ typedef struct sentry_config {
 } sentry_config_t;
 
 /**
+ * @brief Get the sentry configuration object
+ */
+void get_sentry_configuration(sentry_config_t* sentry_config);
+
+/**
  * @brief Initialize sentry if SENTRY_ENABLED flag is set and project slug is
  * configured in control_proxy.yml
  */


### PR DESCRIPTION
## Summary

Made changes suggested in https://github.com/magma/magma/issues/11092 for mme.
Depends on https://github.com/magma/magma/pull/10904.

## Test Plan

- build sessiond local with make and bazel
- manual change of `/etc/opt/magma/gateway.mconfig` did show up at start of sessiond
